### PR TITLE
pkg/server: support serving compressed NAR files

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,13 +23,32 @@ nix copy \
   --to "http://localhost:9000?compression=none" $storePath
 ```
 
-#### Note on compression
-While it's also possible to upload with narfile compression, this is only used
-to compress *uploads* into the binary cache.
+### Binary Cache
+As of now, `nix-casync` can be used as a space-efficient binary cache.
 
-`nix-casync` will decompress compressed narfile uploads on the fly, chunk the
-uncompressed payload, and serve those as `/nar/$narhash.nar`. It will also
-rewrite uploaded `.narinfo` files accordingly.
+You probably want to put some reverse proxy doing SSL in front of it, and add
+some protection on the `PUT` endpoints.
+
+The following section describes some internal behaviour of `nix-casync`, and
+how it treats Narfiles and Narinfo files.
+
+#### Narfiles
+Narfiles can be uploaded with most of the compression mechanisms Nix supports.
+
+The path it's uploaded at `HTTP PUT /nar/….nar[.$suffix]` doesn't really matter.
+
+Files will be decompressed, chunked, and put in a content-addressed store.
+
+Subsequently uploaded `.narinfo` files can refer to that file via the `NarHash`
+attribute, and downloads can happen via `HTTP GET /nar/$narhash.nar[.$suffix]`.
+
+For downloads, only a subset of compression algorithms (fast ones) are
+supported, as those are assembled on the fly and should really only be
+considered a poor-man's Content-Encoding.
+
+##### Another note on compression
+While it's possible to upload with narfile compression, as written above, this
+is only used to compress *uploads* into the binary cache.
 
 This will have some unintuitive implications - if you upload a to
 `/nar/$filehash.nar.zst`, the upload won't be available on that location (but
@@ -39,8 +58,31 @@ This also means `HTTP HEAD` requests to "compressed locations" will `404`, and
 as a result, Nix clients might end up uploading the same `.nar` files multiple
 times. [^1]
 
-Generally, you only want to use compression if connectivity to the binary cache
-is bad, and if you do, use a fast compression algorithm, such as `zstd`.
+Generally, you only want to use compression during upload if the binary cache
+is remote, and if you do, use a fast compression algorithm, such as `zstd`.
+
+By default, downloads are served with ZSTD Compression. This can be tweaked via
+the `--nar-compression` command line parameter.
+
+#### Narinfo files
+Narinfo files describe information about a store path, as well as some
+(redundant) information about the referred .nar file.
+
+Internally, `nix-casync` splits data from `.narinfo` into `NarMeta` and
+`PathInfo` models.
+
+When a Narfile is uploaded, the following checks are made:
+
+ - The .narinfo file refers to a Narfile (via NarHash) that already exists in
+   `nix-casync`.
+ - The `References` field matches with what `nix-casync`'s internal bookkeeping
+   of References in `NarMeta` matches.
+   Right now, that field is populated on the first `.narinfo` upload , but as
+   it's possible to determine the references just by looking at the `.nar` file
+   itself, a reference scanner could be added to `nix-casync` directly.
+ - All `References` in the uploaded `.narinfo` refer to `PathInfo` (aka
+ - `.narinfo` files) that were already uploaded to `nix-casync`.
+
 
 
 [^1]: Nix won't upload the same store path multiple times, as it checks

--- a/README.md
+++ b/README.md
@@ -58,8 +58,9 @@ This also means `HTTP HEAD` requests to "compressed locations" will `404`, and
 as a result, Nix clients might end up uploading the same `.nar` files multiple
 times. [^1]
 
-Generally, you only want to use compression during upload if the binary cache
-is remote, and if you do, use a fast compression algorithm, such as `zstd`.
+If the binary cache is remote, it is preferable to use compression during
+upload to reduce bandwidth usage. In that case, using a fast compression
+algorithm, such as `zstd` is recommended.
 
 By default, downloads are served with ZSTD Compression. This can be tweaked via
 the `--nar-compression` command line parameter.

--- a/cmd/nix_casync/main.go
+++ b/cmd/nix_casync/main.go
@@ -17,8 +17,9 @@ import (
 
 var CLI struct {
 	Serve struct {
-		CachePath  string `name:"cache-path" help:"Path to use for a local cache, containing castr, caibx and narinfo files." type:"path" default:"/var/cache/nix-casync"`
-		ListenAddr string `name:"listen-addr" help:"The address this service listens on" type:"string" default:"[::]:9000"`
+		CachePath      string `name:"cache-path" help:"Path to use for a local cache, containing castr, caibx and narinfo files." type:"path" default:"/var/cache/nix-casync"`
+		NarCompression string `name:"nar-compression" help:"The compression algorithm to advertise .nar files with (zstd,gzip,brotli,none)" enum:"zstd,gzip,brotli,none" type:"string" default:"zstd"`
+		ListenAddr     string `name:"listen-addr" help:"The address this service listens on" type:"string" default:"[::]:9000"`
 	} `cmd serve:"Serve a local nix cache."`
 }
 
@@ -41,7 +42,7 @@ func main() {
 			log.Fatal(err)
 		}
 
-		s := server.NewServer(blobStore, metadataStore)
+		s := server.NewServer(blobStore, metadataStore, CLI.Serve.NarCompression)
 		defer s.Close()
 
 		c := make(chan os.Signal, 1)

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/frankban/quicktest v1.14.0 // indirect
 	github.com/go-chi/chi v1.5.4
 	github.com/go-chi/chi/v5 v5.0.7
-	github.com/numtide/go-nix v0.0.0-20211213202258-b19b10aa1495
+	github.com/numtide/go-nix v0.0.0-20211215191921-37a8ad2f9e4f
 	github.com/pierrec/lz4 v2.6.1+incompatible
 	github.com/sirupsen/logrus v1.8.1
 	github.com/stretchr/testify v1.6.1

--- a/go.sum
+++ b/go.sum
@@ -200,8 +200,8 @@ github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
-github.com/numtide/go-nix v0.0.0-20211213202258-b19b10aa1495 h1:7pOUbmTehLVAkoQEfYDwEvvSMkY/XwCz/W3TtBOtXnk=
-github.com/numtide/go-nix v0.0.0-20211213202258-b19b10aa1495/go.mod h1:QdjLlYQnNqfJRhTF9YJTfIt902z6yufXmI1xy+PwGMg=
+github.com/numtide/go-nix v0.0.0-20211215191921-37a8ad2f9e4f h1:tBFsbD8RZmpPG/f8A6ZrTUXXWXTvCdDxBJ+FBWizYKo=
+github.com/numtide/go-nix v0.0.0-20211215191921-37a8ad2f9e4f/go.mod h1:QdjLlYQnNqfJRhTF9YJTfIt902z6yufXmI1xy+PwGMg=
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/pierrec/lz4 v2.6.1+incompatible h1:9UY3+iC23yxF0UfGaYrGplQ+79Rg+h/q9FV9ix19jjM=

--- a/pkg/server/compression/compressor.go
+++ b/pkg/server/compression/compressor.go
@@ -9,31 +9,12 @@ import (
 	"github.com/datadog/zstd"
 )
 
-type dummyCloser struct {
-	io.WriteCloser
-	w io.Writer
-}
-
-func NewDummyCloser(w io.Writer) io.WriteCloser {
-	return &dummyCloser{w: w}
-}
-
-func (d *dummyCloser) Write(p []byte) (n int, err error) {
-	return d.w.Write(p)
-}
-
-func (d *dummyCloser) Close() error {
-	return nil
-}
-
 // NewCompressor returns an io.WriteCloser that compresses its input.
 // The compression type needs to be specified upfront.
 // Only cheap compression is supported, as this is assembled on the fly, and acts as a poorman's content-encoding.
 // It's the callers responsibility to close the reader when done.
 func NewCompressor(w io.Writer, compressionType string) (io.WriteCloser, error) {
 	switch compressionType {
-	case "none":
-		return NewDummyCloser(w), nil
 	case "br":
 		b := brotli.NewWriterLevel(w, brotli.BestSpeed)
 		return b, nil

--- a/pkg/server/compression/compressor.go
+++ b/pkg/server/compression/compressor.go
@@ -1,0 +1,57 @@
+package compression
+
+import (
+	"compress/gzip"
+	"fmt"
+	"io"
+
+	"github.com/andybalholm/brotli"
+	"github.com/datadog/zstd"
+)
+
+type dummyCloser struct {
+	io.WriteCloser
+	w io.Writer
+}
+
+func NewDummyCloser(w io.Writer) io.WriteCloser {
+	return &dummyCloser{w: w}
+}
+
+func (d *dummyCloser) Write(p []byte) (n int, err error) {
+	return d.w.Write(p)
+}
+
+func (d *dummyCloser) Close() error {
+	return nil
+}
+
+// NewCompressor returns an io.WriteCloser that compresses its input.
+// The compression type needs to be specified upfront.
+// Only cheap compression is supported, as this is assembled on the fly, and acts as a poorman's content-encoding.
+// It's the callers responsibility to close the reader when done.
+func NewCompressor(w io.Writer, compressionType string) (io.WriteCloser, error) {
+	switch compressionType {
+	case "none":
+		return NewDummyCloser(w), nil
+	case "br":
+		b := brotli.NewWriterLevel(w, brotli.BestSpeed)
+		return b, nil
+	case "gzip":
+		return gzip.NewWriterLevel(w, gzip.BestSpeed)
+	case "zstd":
+		z := zstd.NewWriterLevel(w, zstd.BestSpeed)
+		return z, nil
+	}
+	return nil, fmt.Errorf("unsupported compression type: %v", compressionType)
+}
+
+// NewCompressorBySuffix returns an io.WriteCloser that compresses its input.
+func NewCompressorBySuffix(w io.Writer, compressionSuffix string) (io.WriteCloser, error) {
+	// try to lookup the compression type from compressionSuffixToType
+	if compressionType, ok := CompressionSuffixToType[compressionSuffix]; ok {
+		return NewCompressor(w, compressionType)
+	}
+
+	return nil, fmt.Errorf("unknown compression suffix: %v", compressionSuffix)
+}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1,10 +1,13 @@
 package server
 
 import (
+	"compress/gzip"
 	"fmt"
 	"io"
 	"net/http"
 
+	"github.com/andybalholm/brotli"
+	"github.com/datadog/zstd"
 	"github.com/flokli/nix-casync/pkg/server/compression"
 	"github.com/flokli/nix-casync/pkg/store"
 	"github.com/flokli/nix-casync/pkg/store/blobstore"
@@ -23,10 +26,12 @@ type Server struct {
 	blobStore     blobstore.BlobStore
 	metadataStore metadatastore.MetadataStore
 
+	narServeCompression string // zstd,gzip,brotli,none
+
 	io.Closer
 }
 
-func NewServer(blobStore blobstore.BlobStore, metadataStore metadatastore.MetadataStore) *Server {
+func NewServer(blobStore blobstore.BlobStore, metadataStore metadatastore.MetadataStore, narServeCompression string) *Server {
 	r := chi.NewRouter()
 	r.Get("/", func(w http.ResponseWriter, r *http.Request) {
 		w.Write([]byte("nix-casync"))
@@ -38,10 +43,12 @@ func NewServer(blobStore blobstore.BlobStore, metadataStore metadatastore.Metada
 	})
 
 	s := &Server{
-		Handler:       r,
-		blobStore:     blobStore,
-		metadataStore: metadataStore,
+		Handler:             r,
+		blobStore:           blobStore,
+		metadataStore:       metadataStore,
+		narServeCompression: narServeCompression,
 	}
+
 	s.RegisterNarHandlers()
 	s.RegisterNarinfoHandlers()
 	return s
@@ -103,10 +110,7 @@ func (s *Server) handleNarinfo(w http.ResponseWriter, r *http.Request) {
 		narInfo := &narinfo.NarInfo{
 			StorePath:   pathInfo.StorePath(),
 			URL:         "nar/" + narhashStr + ".nar",
-			Compression: "none",
-
-			FileHash: narHash,
-			FileSize: narMeta.Size,
+			Compression: s.narServeCompression,
 
 			NarHash: narHash,
 			NarSize: narMeta.Size,
@@ -120,6 +124,14 @@ func (s *Server) handleNarinfo(w http.ResponseWriter, r *http.Request) {
 			Signatures: pathInfo.NarinfoSignatures,
 
 			CA: pathInfo.CA,
+		}
+
+		if s.narServeCompression != "none" {
+			if s.narServeCompression == "zstd" {
+				narInfo.URL = narInfo.URL + ".zst"
+			} else {
+				narInfo.URL = narInfo.URL + "." + s.narServeCompression
+			}
 		}
 
 		// render narinfo
@@ -189,22 +201,22 @@ func (s *Server) RegisterNarHandlers() {
 	patternPlain := "/nar/{narhash:^[" + nixbase32.Alphabet + "]{52}$}.nar"
 	patternCompressed := patternPlain + `{compressionSuffix:^(\.\w+)$}`
 
-	// We only serve plain Narfiles
 	s.Handler.Get(patternPlain, s.handleNar)
 	s.Handler.Head(patternPlain, s.handleNar)
+	s.Handler.Get(patternCompressed, s.handleNar)
+	s.Handler.Head(patternCompressed, s.handleNar)
 
 	// When Nix uploads compressed paths (if compression=none is not set),
 	// we simply can't know if a file exists or not.
-	// Nix uploads /nar/$filehash.nar.$compressionType, not /nar/$narhash.nar.$compressionType,
-	// but we content-address the decompressed contents.
-	// Register a dumb HEAD handler that returns a 404 for all compressed paths.
+	// Nix uploads (and checks for existence of) /nar/$filehash.nar.$compressionType,
+	// not /nar/$narhash.nar.$compressionType (which is what we use)
+	// We content-hash the decompressed contents and discard the compressed uploaded payload,
+	// so there's no way to know if /nar/$filehash.nar.$compressionType was uploaded
+	// This means we will return 404 whenever Nix tries to upload a compressed NAR file
 	// This will cause Nix to unnecessarily upload Narfiles multiple times.
 	// It's not as bad as it sounds, as this only affects multiple Narinfo files
-	// referencing the same Narfile.
-	// Nix first checks the Narinfo files for existence, and doesn't update the Narfile.
-	s.Handler.Head(patternCompressed, func(w http.ResponseWriter, r *http.Request) {
-		http.Error(w, "Can't know for compressed Narfiles", http.StatusNotFound)
-	})
+	// referencing the same Narfile (and Nix might locally cache the fact it already uploaded
+	// that Narfile)
 
 	s.Handler.Put(patternPlain, s.handleNar)
 	s.Handler.Put(patternCompressed, s.handleNar)
@@ -215,23 +227,48 @@ func (s *Server) handleNar(w http.ResponseWriter, r *http.Request) {
 		narhashStr := chi.URLParam(r, "narhash")
 		narhash, err := nixbase32.DecodeString(narhashStr)
 		if err != nil {
-			http.Error(w, fmt.Sprintf("handle-narinfo: %v", err), http.StatusBadRequest)
+			http.Error(w, fmt.Sprintf("Unable to decode narHash %v: %v", narhashStr, err), http.StatusBadRequest)
 		}
-		r, size, err := s.blobStore.GetBlob(r.Context(), narhash)
+		blobReader, size, err := s.blobStore.GetBlob(r.Context(), narhash)
 		if err != nil {
 			status := http.StatusInternalServerError
 			if err == store.ErrNotFound {
 				status = http.StatusNotFound
 			}
-			http.Error(w, fmt.Sprintf("GET handle-nar: %v", err), status)
+			http.Error(w, fmt.Sprintf("Error retrieving narfile with hash %v: %v", narhashStr, err), status)
 			return
 		}
-		defer r.Close()
+		defer blobReader.Close()
+
+		// check compression suffix, and serve a compressed file depending on that.
+		// We only support zstd, gzip, brotli and none, as the others are way too CPU-intensive,
+		// and never advertised anyways.
+		compressionSuffix := chi.URLParam(r, "compressionSuffix")
+		if !(compressionSuffix == "" || compressionSuffix == ".zst" || compressionSuffix == ".gz" || compressionSuffix == ".br") {
+			// In case of another compression suffix, serve a 404 (as Nix might send a HEAD request while trying to upload xz, for example)
+			http.Error(w, fmt.Sprintf("Unsupported compression suffix: %v", compressionSuffix), http.StatusNotFound)
+			return
+		}
 
 		w.Header().Add("Content-Type", "application/x-nix-nar")
 		w.Header().Add("Content-Length", fmt.Sprintf("%d", size))
-		io.Copy(w, r)
 
+		switch compressionSuffix {
+		case "":
+			io.Copy(w, blobReader)
+		case ".zst":
+			zstdWriter := zstd.NewWriter(w)
+			defer zstdWriter.Close()
+			io.Copy(zstdWriter, blobReader)
+		case ".gz":
+			gzipWriter := gzip.NewWriter(w)
+			defer gzipWriter.Close()
+			io.Copy(gzipWriter, blobReader)
+		case ".br":
+			brotliWriter := brotli.NewWriter(w)
+			defer brotliWriter.Close()
+			io.Copy(brotliWriter, blobReader)
+		}
 		return
 	}
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -123,13 +123,11 @@ func (s *Server) handleNarinfo(w http.ResponseWriter, r *http.Request) {
 			CA: pathInfo.CA,
 		}
 
-		if s.narServeCompression != "none" {
-			if s.narServeCompression == "zstd" {
-				narInfo.URL = narInfo.URL + ".zst"
-			} else {
-				narInfo.URL = narInfo.URL + "." + s.narServeCompression
-			}
+		suffix, err := compression.CompressionTypeToSuffix(s.narServeCompression)
+		if err != nil {
+			http.Error(w, fmt.Sprintf("invalid compression type: %v", err), http.StatusInternalServerError)
 		}
+		narInfo.URL = narInfo.URL + suffix
 
 		// render narinfo
 		narinfoContent := narInfo.String()

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -251,7 +251,11 @@ func (s *Server) handleNar(w http.ResponseWriter, r *http.Request) {
 		w.Header().Add("Content-Type", "application/x-nix-nar")
 		w.Header().Add("Content-Length", fmt.Sprintf("%d", size))
 
-		io.Copy(compressedWriter, blobReader)
+		_, err = io.Copy(compressedWriter, blobReader)
+		if err != nil {
+			log.Errorf("error sending narfile to client: %v", err)
+			return
+		}
 		defer compressedWriter.Close()
 		return
 	}

--- a/test/compression_none/dr76fsw7d6ws3pymafx0w0sn4rzbw7c9_returned_no_compression.narinfo
+++ b/test/compression_none/dr76fsw7d6ws3pymafx0w0sn4rzbw7c9_returned_no_compression.narinfo
@@ -1,0 +1,7 @@
+StorePath: /nix/store/dr76fsw7d6ws3pymafx0w0sn4rzbw7c9-etc-os-release
+URL: nar/0mw6qwsrz35cck0wnjgmfnjzwnjbspsyihnfkng38kxghdc9k9zd.nar
+Compression: none
+NarHash: sha256:0mw6qwsrz35cck0wnjgmfnjzwnjbspsyihnfkng38kxghdc9k9zd
+NarSize: 464
+References: 
+Deriver: hip5s2x9g0mqvamqhgkjxfhjw9mlm8j9-etc-os-release.drv

--- a/test/compression_none/dr76fsw7d6ws3pymafx0w0sn4rzbw7c9_returned_zstd.narinfo
+++ b/test/compression_none/dr76fsw7d6ws3pymafx0w0sn4rzbw7c9_returned_zstd.narinfo
@@ -1,0 +1,7 @@
+StorePath: /nix/store/dr76fsw7d6ws3pymafx0w0sn4rzbw7c9-etc-os-release
+URL: nar/0mw6qwsrz35cck0wnjgmfnjzwnjbspsyihnfkng38kxghdc9k9zd.nar.zst
+Compression: zstd
+NarHash: sha256:0mw6qwsrz35cck0wnjgmfnjzwnjbspsyihnfkng38kxghdc9k9zd
+NarSize: 464
+References: 
+Deriver: hip5s2x9g0mqvamqhgkjxfhjw9mlm8j9-etc-os-release.drv


### PR DESCRIPTION
With the `--nar-compression flag`, people can modify the compression
algorithm that's used to transfer `.nar` files.

The `.narinfo` files will contain a `Compression` field set to the
compression specified via that flag.

Luckily, Nix doesn't really care about the `FileSize` and `FileHash`
parameters when downloading - it only validates the decompressed `.nar`
file.

The HTTP handlers are able to serve any of the supported compression
algorithms.

Note only a subset of (fast) compression algorithms is supported, as
this is really only used as a poorman's alternative to Content-Encoding.