### PR TITLE
Misc Error handling fixes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/numtide/go-nix v0.0.0-20211215191921-37a8ad2f9e4f
 	github.com/pierrec/lz4 v2.6.1+incompatible
 	github.com/sirupsen/logrus v1.8.1
-	github.com/stretchr/testify v1.6.1
+	github.com/stretchr/testify v1.7.0
 	github.com/ulikunitz/xz v0.5.10
+	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -256,6 +256,8 @@ github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81P
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
+github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
 github.com/ulikunitz/xz v0.5.10 h1:t92gobL9l3HE202wg3rlk19F6X+JOxl9BBrCCMYEYd8=
@@ -521,6 +523,8 @@ gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b h1:h8qDotaEPuJATrMmW04NCwg7v22aHH28wwpauUhK9Oo=
+gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190106161140-3f1c8253044a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190418001031-e561f6794a2a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -52,12 +52,15 @@ func NewServer(blobStore blobstore.BlobStore, metadataStore metadatastore.Metada
 }
 
 func (s *Server) Close() error {
-	// TODO: how do we ensure we close both?
-	err := s.blobStore.Close()
-	if err != nil {
-		return err
+	err1 := s.blobStore.Close()
+	err2 := s.metadataStore.Close()
+	if err1 != nil {
+		return err1
 	}
-	return s.metadataStore.Close()
+	if err2 != nil {
+		return err2
+	}
+	return nil
 }
 
 func (s *Server) RegisterNarinfoHandlers() {

--- a/pkg/store/binarycachestore.go
+++ b/pkg/store/binarycachestore.go
@@ -1,9 +1,0 @@
-package store
-
-import (
-	"errors"
-)
-
-var (
-	ErrNotFound = errors.New("not found")
-)

--- a/pkg/store/blobstore/blobstore_test.go
+++ b/pkg/store/blobstore/blobstore_test.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"testing"
 
-	"github.com/flokli/nix-casync/pkg/store"
 	"github.com/numtide/go-nix/nixbase32"
 	"github.com/stretchr/testify/assert"
 )
@@ -66,7 +65,7 @@ func testBlobStore(t *testing.T, blobStore BlobStore) {
 	t.Run("GetBlobNotFound", func(t *testing.T) {
 		_, _, err := blobStore.GetBlob(context.Background(), narhash)
 		if assert.Error(t, err) {
-			assert.Equal(t, store.ErrNotFound, err)
+			assert.ErrorIsf(t, err, os.ErrNotExist, "on a non-existent blob, there should be a os.ErrNotExist in the error chain")
 		}
 	})
 

--- a/pkg/store/blobstore/casync_store.go
+++ b/pkg/store/blobstore/casync_store.go
@@ -6,7 +6,6 @@ import (
 	"io"
 	"os"
 
-	"github.com/flokli/nix-casync/pkg/store"
 	"github.com/folbricht/desync"
 )
 
@@ -72,9 +71,6 @@ func (c *CasyncStore) GetBlob(ctx context.Context, sha256 []byte) (io.ReadCloser
 	// retrieve .caidx
 	caidx, err := c.localIndexStore.GetIndex(hex.EncodeToString(sha256))
 	if err != nil {
-		if os.IsNotExist(err) {
-			return nil, 0, store.ErrNotFound
-		}
 		return nil, 0, err
 	}
 

--- a/pkg/store/blobstore/memory_store.go
+++ b/pkg/store/blobstore/memory_store.go
@@ -7,9 +7,8 @@ import (
 	"encoding/hex"
 	"hash"
 	"io"
+	"os"
 	"sync"
-
-	"github.com/flokli/nix-casync/pkg/store"
 )
 
 // MemoryStore implements BlobStore
@@ -45,7 +44,7 @@ func (m *MemoryStore) GetBlob(ctx context.Context, sha256 []byte) (io.ReadCloser
 	if ok {
 		return io.NopCloser(bytes.NewReader(v)), int64(len(v)), nil
 	}
-	return nil, 0, store.ErrNotFound
+	return nil, 0, os.ErrNotExist
 }
 
 // memoryStoreWriter implements WriteCloseHasher

--- a/pkg/store/metadatastore/metadata_store_test.go
+++ b/pkg/store/metadatastore/metadata_store_test.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"testing"
 
-	"github.com/flokli/nix-casync/pkg/store"
 	"github.com/numtide/go-nix/nar/narinfo"
 	"github.com/stretchr/testify/assert"
 )
@@ -92,7 +91,7 @@ func testMetadataStore(t *testing.T, metadataStore MetadataStore) {
 		t.Run("GetNarMetaNotFound", func(t *testing.T) {
 			_, err := metadataStore.GetNarMeta(context.Background(), tdA.narMeta.NarHash)
 			if assert.Error(t, err) {
-				assert.Equal(t, store.ErrNotFound, err)
+				assert.ErrorIsf(t, err, os.ErrNotExist, "on a non-existent NarMeta, there should be a os.ErrNotExist in the error chain")
 			}
 		})
 
@@ -117,7 +116,7 @@ func testMetadataStore(t *testing.T, metadataStore MetadataStore) {
 		t.Run("GetPathInfoNotFound", func(t *testing.T) {
 			_, err := metadataStore.GetPathInfo(context.Background(), tdA.pathInfo.OutputHash)
 			if assert.Error(t, err) {
-				assert.Equal(t, store.ErrNotFound, err)
+				assert.ErrorIsf(t, err, os.ErrNotExist, "on a non-existent PathInfo, there should be a os.ErrNotExist in the error chain")
 			}
 		})
 

--- a/pkg/store/metadatastore/types.go
+++ b/pkg/store/metadatastore/types.go
@@ -74,7 +74,7 @@ func ParseNarinfo(narinfo *narinfo.NarInfo) (*PathInfo, *NarMeta, error) {
 	for _, referenceStr := range narinfo.References {
 		hashRef, err := nixbase32.DecodeString(referenceStr[0:32])
 		if err != nil {
-			return nil, nil, fmt.Errorf("unable to decode hash %v in reference %v", referenceStr, narinfo.References)
+			return nil, nil, fmt.Errorf("unable to decode hash %v in reference %v: %w", referenceStr, narinfo.References, err)
 		}
 		references = append(references, hashRef)
 	}


### PR DESCRIPTION
 - Improve and unify error messages
 - Make the `Server` `Close()` function more reliable (try to close all stores in case of an error)
 - Remove `store.ErrNotFound` sentinel error in favor of wrapping errors and using os.ErrNotExist