### PR TITLE
pkg/server: allow specifying Priority

### DIFF
--- a/cmd/nix_casync/main.go
+++ b/cmd/nix_casync/main.go
@@ -20,6 +20,7 @@ var CLI struct {
 		CachePath      string `name:"cache-path" help:"Path to use for a local cache, containing castr, caibx and narinfo files." type:"path" default:"/var/cache/nix-casync"`
 		NarCompression string `name:"nar-compression" help:"The compression algorithm to advertise .nar files with (zstd,gzip,brotli,none)" enum:"zstd,gzip,brotli,none" type:"string" default:"zstd"`
 		ListenAddr     string `name:"listen-addr" help:"The address this service listens on" type:"string" default:"[::]:9000"`
+		Priority       int    `name:"priority" help:"What priority to advertise in nix-cache-info. Defaults to 40." type:"int" default:40`
 	} `cmd serve:"Serve a local nix cache."`
 }
 
@@ -42,7 +43,7 @@ func main() {
 			log.Fatal(err)
 		}
 
-		s := server.NewServer(blobStore, metadataStore, CLI.Serve.NarCompression)
+		s := server.NewServer(blobStore, metadataStore, CLI.Serve.NarCompression, CLI.Serve.Priority)
 		defer s.Close()
 
 		c := make(chan os.Signal, 1)

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -29,15 +29,14 @@ type Server struct {
 	io.Closer
 }
 
-func NewServer(blobStore blobstore.BlobStore, metadataStore metadatastore.MetadataStore, narServeCompression string) *Server {
+func NewServer(blobStore blobstore.BlobStore, metadataStore metadatastore.MetadataStore, narServeCompression string, priority int) *Server {
 	r := chi.NewRouter()
 	r.Get("/", func(w http.ResponseWriter, r *http.Request) {
 		w.Write([]byte("nix-casync"))
 	})
 
 	r.Get("/nix-cache-info", func(w http.ResponseWriter, r *http.Request) {
-		// TODO: make configurable
-		w.Write([]byte("StoreDir: /nix/store\nWantMassQuery: 1\nPriority: 40"))
+		w.Write([]byte(fmt.Sprintf("StoreDir: /nix/store\nWantMassQuery: 1\nPriority: %d\n", priority)))
 	})
 
 	s := &Server{

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -32,7 +32,7 @@ func TestHandler(t *testing.T) {
 	defer blobStore.Close()
 	metadataStore := metadatastore.NewMemoryStore()
 	defer metadataStore.Close()
-	server := NewServer(blobStore, metadataStore, "zstd")
+	server := NewServer(blobStore, metadataStore, "zstd", 40)
 
 	t.Run("Nar tests", func(t *testing.T) {
 		narhashStr := "0mw6qwsrz35cck0wnjgmfnjzwnjbspsyihnfkng38kxghdc9k9zd"


### PR DESCRIPTION
This allows to customize the value of the `Priority` field advertised in
the `/nix-cache-info` request.