### PR TITLE
pkg/store/blobstore/casync_store: make chunking size configurable, add parallelity

### DIFF
--- a/cmd/nix_casync/main.go
+++ b/cmd/nix_casync/main.go
@@ -21,6 +21,7 @@ var CLI struct {
 		NarCompression string `name:"nar-compression" help:"The compression algorithm to advertise .nar files with (zstd,gzip,brotli,none)" enum:"zstd,gzip,brotli,none" type:"string" default:"zstd"`
 		ListenAddr     string `name:"listen-addr" help:"The address this service listens on" type:"string" default:"[::]:9000"`
 		Priority       int    `name:"priority" help:"What priority to advertise in nix-cache-info. Defaults to 40." type:"int" default:40`
+		AvgChunkSize   int    `name:"avg-chunk-size" help:"The average chunking size to use when chunking NAR files, in bytes. Max is 4 times that, Min is a quarter of this value." type:"int" default:65536`
 	} `cmd serve:"Serve a local nix cache."`
 }
 
@@ -31,7 +32,7 @@ func main() {
 		// initialize casync store
 		castrPath := path.Join(CLI.Serve.CachePath, "castr")
 		caibxPath := path.Join(CLI.Serve.CachePath, "caibx")
-		blobStore, err := blobstore.NewCasyncStore(castrPath, caibxPath) // TODO: ask for more parameters?
+		blobStore, err := blobstore.NewCasyncStore(castrPath, caibxPath, CLI.Serve.AvgChunkSize)
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/pkg/store/blobstore/blobstore_test.go
+++ b/pkg/store/blobstore/blobstore_test.go
@@ -32,7 +32,7 @@ func TestCasyncStore(t *testing.T) {
 	})
 
 	// init casync store
-	caStore, err := NewCasyncStore(castrDir, caidxDir)
+	caStore, err := NewCasyncStore(castrDir, caidxDir, 65536)
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/store/blobstore/casync_store.go
+++ b/pkg/store/blobstore/casync_store.go
@@ -23,7 +23,7 @@ type CasyncStore struct {
 	// TODO: remote store(s)?
 }
 
-func NewCasyncStore(localStoreDir, localIndexStoreDir string) (*CasyncStore, error) {
+func NewCasyncStore(localStoreDir, localIndexStoreDir string, avgChunkSize int) (*CasyncStore, error) {
 
 	// TODO: maybe use MultiStoreWithCache?
 	err := os.MkdirAll(localStoreDir, os.ModePerm)
@@ -53,9 +53,9 @@ func NewCasyncStore(localStoreDir, localIndexStoreDir string) (*CasyncStore, err
 
 		// values stolen from chunker_test.go
 		// TODO: make configurable
-		chunkSizeAvgDefault: 64 * 1024,
-		chunkSizeMinDefault: 64 * 1024 / 4,
-		chunkSizeMaxDefault: 64 * 1024 * 4,
+		chunkSizeAvgDefault: uint64(avgChunkSize),
+		chunkSizeMinDefault: uint64(avgChunkSize) / 4,
+		chunkSizeMaxDefault: uint64(avgChunkSize) * 4,
 	}, nil
 }
 

--- a/pkg/store/blobstore/casync_store.go
+++ b/pkg/store/blobstore/casync_store.go
@@ -5,6 +5,7 @@ import (
 	"encoding/hex"
 	"io"
 	"os"
+	"runtime"
 
 	"github.com/folbricht/desync"
 )
@@ -46,13 +47,17 @@ func NewCasyncStore(localStoreDir, localIndexStoreDir string, avgChunkSize int) 
 		return nil, err
 	}
 
+	concurrency := runtime.NumCPU()
+	if concurrency > 4 {
+		concurrency = 4
+	}
+
 	return &CasyncStore{
 		localStore:      localStore,
 		localIndexStore: localIndexStore,
-		concurrency:     1, // TODO: make configurable
+		concurrency:     concurrency,
 
 		// values stolen from chunker_test.go
-		// TODO: make configurable
 		chunkSizeAvgDefault: uint64(avgChunkSize),
 		chunkSizeMinDefault: uint64(avgChunkSize) / 4,
 		chunkSizeMaxDefault: uint64(avgChunkSize) * 4,


### PR DESCRIPTION
```
commit ed87efca2b79f7ebedb3ff44652bfb478280b9b6
Author: Florian Klink <flokli@flokli.de>
Date:   Thu Jan 13 23:49:07 2022 +0100

    pkg/store/blobstore/casync_store.go: ramp up concurrency
    
    Configure a concurrency of the number of CPUs available to the process,
    up to the maximum of 4.

commit e3cfb4b40b7b1892f7c27099a609d3b34e262c3c
Author: Florian Klink <flokli@flokli.de>
Date:   Thu Jan 13 00:59:24 2022 +0100

    Provide a --avg-chunk-size parameter
    
    This controls the average chunking size to use when receiving Narfiles.
    
    The min and max values are a fifth and four times that value,
    respectively.
```

Fixes #1